### PR TITLE
refactor the test suite

### DIFF
--- a/client/quote_ye.go
+++ b/client/quote_ye.go
@@ -12,9 +12,9 @@ type Response struct {
 
 func QuoteKanyeWest(censored bool) string {
 	data := GetQuote()
-	var resBody Response
-	json.Unmarshal(data, &resBody)
-	quote := "\"" + resBody.Quote + "\""
+	var respBody Response
+	json.Unmarshal(data, &respBody)
+	quote := "\"" + respBody.Quote + "\""
 
 	if goaway.IsProfane(quote) && censored {
 		return goaway.Censor(quote)

--- a/test/get_quote_test.go
+++ b/test/get_quote_test.go
@@ -1,22 +1,23 @@
 package main
 
 import (
-	"encoding/json"
+	"net/http"
+	"os"
 	"testing"
-
-	ye "github.com/i8abyte/ye/api"
 )
 
-func testIsRespBodyEmpty(t *testing.T, respBody ye.Response) {
-	if len(respBody.Quote) < 1 {
-		t.Errorf("The name/value pair in the body of the HTTP response does not contain a value")
+func testIsHttpRequestSuccessful(t *testing.T, uri string) {
+	resp, err := http.Get(uri)
+	if err != nil {
+		t.Errorf("There was no response from the server: %s", uri)
+		os.Exit(1)
+	}
+	if resp.StatusCode > 299 {
+		t.Errorf("Response failed with the status code: %d", resp.StatusCode)
 	}
 }
 
 func TestGetQuote(t *testing.T) {
-	data := ye.GetQuote()
-	var respBody ye.Response
-	json.Unmarshal(data, &respBody)
-
-	testIsRespBodyEmpty(t, respBody)
+	uri := "https://api.kanye.rest"
+	testIsHttpRequestSuccessful(t, uri)
 }

--- a/test/quote_ye_test.go
+++ b/test/quote_ye_test.go
@@ -6,8 +6,14 @@ import (
 	"testing"
 
 	goaway "github.com/TwiN/go-away"
-	ye "github.com/i8abyte/ye/api"
+	ye "github.com/i8abyte/ye/client"
 )
+
+func testIsThereAQuote(t *testing.T, respBody ye.Response) {
+	if len(respBody.Quote) < 1 {
+		t.Errorf("The name/value pair in the body of the HTTP response does not contain a valid value")
+	}
+}
 
 func testIsQuoteCensored(t *testing.T, quote string) {
 	if goaway.IsProfane(quote) {
@@ -23,7 +29,7 @@ func TestQuoteKanyeWest(t *testing.T) {
 	data := ye.GetQuote()
 	var respBody ye.Response
 	json.Unmarshal(data, &respBody)
+	testIsThereAQuote(t, respBody)
 	quote := "\"" + respBody.Quote + "\""
-
 	testIsQuoteCensored(t, quote)
 }


### PR DESCRIPTION
Refactor the unit tests to reflect the changes made to the HTTP GET request.

- rename the module from "api" to "client"
- add a test case for error handling of the HTTP GET request
  - if there is a response from the server
  - if the response is successful
- move the test case to check for an empty string in the response body